### PR TITLE
[di-245] Add devel middleware and sample controller

### DIFF
--- a/src/Api/Controllers/DevelController.php
+++ b/src/Api/Controllers/DevelController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Api\Controllers;
+
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+use Api\Controllers\ApiController;
+use Api\Helpers\JsonApiResponse;
+
+class DevelController extends ApiController
+{
+    public function routes($app)
+    {
+        $app->post('/sample', [$this, 'sample']);
+    }
+
+    public function sample(Request $request, Response $response, $args)
+    {
+        return (new JsonApiResponse($response))->data([
+            'args' => $args,
+            'body' => $this->parseBody($request)
+        ]);
+    }
+}

--- a/src/Api/Middleware/DevelMiddleware.php
+++ b/src/Api/Middleware/DevelMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Api\Middleware;
+
+use Exception;
+
+class DevelMiddleware
+{
+    protected $logger = null;
+
+    public function __construct($logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function __invoke($request, $response, $next)
+    {
+        $env = getenv('APP_ENV');
+        if (!in_array($env, ['devel', 'development'])) {
+            $this->logger->error(strtr(
+                '[$class] devel middleware denied access in environment: $env',
+                ['$class' => get_class($this), '$env' => $env]
+            ));
+            throw new Exception('Access denied');
+        }
+        return $next($request, $response);
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -17,9 +17,11 @@ use Api\Helpers\SessionMiddleware;
 use Api\Helpers\LoggerMiddleware;
 
 use Api\Middleware\AuthMiddleware;
+use Api\Middleware\DevelMiddleware;
 
 use Api\Controllers\AdminController;
 use Api\Controllers\CommonController;
+use Api\Controllers\DevelController;
 use Api\Controllers\MapsController;
 use Api\Controllers\SessionController;
 
@@ -113,6 +115,13 @@ $app->group('/admin/{regionId}', function () use ($app) {
         $container->get('db')->getCoreConnection(),
         Role::ROLE_ADMINREGION
     )
+);
+
+$app->group('/devel', function () use ($app) {
+    $container = $app->getContainer();
+    (new DevelController($container, $container->get('logger')))->routes($app);
+})->add(
+    new DevelMiddleware($container->get('logger'))
 );
 
 $app->group('/common', function () use ($app) {


### PR DESCRIPTION
* devel controller routes are only available in development environment,
  so we use a simple devel middleware to compare this

Issue #245 - https://desinventar.atlassian.net/browse/DI-245
